### PR TITLE
Add Infiltrator.jl to the list of actively maintained Julia debuggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 - [Debugger.jl](https://github.com/JuliaDebug/Debugger.jl) - the official Julia debugger
 - [Rebugger.jl](https://github.com/timholy/Rebugger.jl) - an expression-level debugger for Julia with a provocative command-line (REPL) user interface
 - [MagneticReadHead.jl](https://github.com/oxinabox/MagneticReadHead.jl) - a powerful Julia debugger based on [Cassette.jl](https://github.com/jrevels/Cassette.jl)
+- [Infiltrator.jl](https://github.com/JuliaDebug/Infiltrator.jl) - allows you to set a breakpoint in a local context, inspect local variables and the call stack, and execute arbitrary statements in the context of the current function's module
 
 You might also enjoy:
 


### PR DESCRIPTION
Infiltrator.jl (https://github.com/JuliaDebug/Infiltrator.jl) will probably meet the needs of many people that go looking for a simple Julia debugger. I figure that it would be a good idea to include Infiltrator.jl in the list of debuggers that we suggest in the Gallium.jl README.